### PR TITLE
Do not break .flatten.

### DIFF
--- a/lib/xml_hate/node.rb
+++ b/lib/xml_hate/node.rb
@@ -27,6 +27,8 @@ module XmlHate
       @_keys.reduce({}) { |t, i| t.merge(i => self.send(i) ) }
     end
 
+    def to_ary; nil; end
+
     private
 
     def all_items_in_the_hash_that_are_not_nil(the_hash)

--- a/spec/xml_hate/node_spec.rb
+++ b/spec/xml_hate/node_spec.rb
@@ -149,4 +149,11 @@ describe XmlHate::Node do
     end
   end
 
+  describe "to_ary" do
+    it "should return nil, allowing this class to be used with .flatten" do
+      object = XmlHate::Node.new({})
+      object.to_ary.nil?.must_equal true
+    end
+  end
+
 end


### PR DESCRIPTION
Seems that .flatten breaks due to to_ary returning an empty string.  This fixes that.
